### PR TITLE
Add SNOS RPC method duration metrics

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,71 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
+  manual-build-image:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-pathfinder
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          echo -n "pathfinder_version=" >> "$GITHUB_OUTPUT"
+          git describe --tags --dirty --always >> "$GITHUB_OUTPUT"
+
+      - name: Tags
+        id: tag
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/pathfinder"
+          SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
+          MANUAL_SHA="$IMAGE:manual-$SHA"
+          TAGS="$MANUAL_SHA"
+
+          echo "manual-sha=$MANUAL_SHA" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            MANUAL_LATEST="$IMAGE:manual-latest"
+            echo "manual-latest=$MANUAL_LATEST" >> "$GITHUB_OUTPUT"
+            TAGS="$TAGS"$'\n'"$MANUAL_LATEST"
+          fi
+
+          echo "tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+
+      - name: Build Docker Image and Publish
+        uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}
+          tags: ${{ steps.tag.outputs.tags }}
+
   # Build a docker image unless this was triggered by a release.
   build-image:
-    if: github.event_name != 'release'
+    if: github.event_name == 'push'
     runs-on: pathfinder-large-ubuntu
     steps:
       - name: Determine Docker image metadata

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -23,6 +23,13 @@ mod subscription;
 
 pub use method::handle_json_rpc_body;
 
+const SNOS_RPC_METHOD_DURATION_SECONDS: &str = "pathfinder_snos_rpc_method_duration_seconds";
+const SNOS_RPC_METHODS: &[&str] = &[
+    "starknet_getStorageProof",
+    "starknet_getClass",
+    "starknet_getClassHashAt",
+];
+
 #[derive(Clone)]
 pub struct RpcRouter {
     pub context: RpcContext,
@@ -126,10 +133,12 @@ impl RpcRouter {
 
         metrics::increment_counter!("rpc_method_calls_total", "method" => method_name, "version" => self.version.to_str());
 
+        let start = std::time::Instant::now();
         let method = method
             .invoke(self.context.clone(), request.params, self.version)
             .instrument(tracing::debug_span!("rpc_call", method=%method_name));
         let result = std::panic::AssertUnwindSafe(method).catch_unwind().await;
+        record_snos_rpc_method_duration(method_name, start.elapsed());
 
         let output = match result {
             Ok(output) => output,
@@ -151,6 +160,18 @@ impl RpcRouter {
             version: self.version,
         })
     }
+}
+
+fn record_snos_rpc_method_duration(method_name: &'static str, duration: std::time::Duration) {
+    if !SNOS_RPC_METHODS.contains(&method_name) {
+        return;
+    }
+
+    metrics::histogram!(
+        SNOS_RPC_METHOD_DURATION_SECONDS,
+        duration.as_secs_f64(),
+        "method" => method_name
+    );
 }
 
 // A slight variation on the axum json extractor.


### PR DESCRIPTION
## Summary
- add a dedicated `pathfinder_snos_rpc_method_duration_seconds` histogram for SNOS-facing RPC methods
- record only the low-cardinality `method` label for `starknet_getStorageProof`, `starknet_getClass`, and `starknet_getClassHashAt`
- update the existing `Docker` workflow so manual dispatch builds a Madara-style GHCR image for `linux/amd64`

## Image
- Built successfully via GitHub Actions run: https://github.com/karnotxyz/pathfinder/actions/runs/28108834120
- Image: `ghcr.io/karnotxyz/pathfinder:manual-58f395b`
- Digest: `sha256:7919a3d53714e43b7554b5ab03bb10ae67d8ca6a48bc2e299daa97bdfd6e5c59`

## Validation
- `cargo check -p pathfinder-rpc`

## Notes
- The manual Docker path uses the Blacksmith 8-vCPU Ubuntu runner and explicitly builds `linux/amd64`, matching the effective architecture of Madara manual image builds.