### PR TITLE
Add SNOS RPC method duration metrics

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,71 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
+  manual-build-image:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-pathfinder
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          echo -n "pathfinder_version=" >> "$GITHUB_OUTPUT"
+          git describe --tags --dirty --always >> "$GITHUB_OUTPUT"
+
+      - name: Tags
+        id: tag
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/pathfinder"
+          SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
+          MANUAL_SHA="$IMAGE:manual-$SHA"
+          TAGS="$MANUAL_SHA"
+
+          echo "manual-sha=$MANUAL_SHA" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            MANUAL_LATEST="$IMAGE:manual-latest"
+            echo "manual-latest=$MANUAL_LATEST" >> "$GITHUB_OUTPUT"
+            TAGS="$TAGS"$'\n'"$MANUAL_LATEST"
+          fi
+
+          echo "tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+
+      - name: Build Docker Image and Publish
+        uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}
+          tags: ${{ steps.tag.outputs.tags }}
+
   # Build a docker image unless this was triggered by a release.
   build-image:
-    if: github.event_name != 'release'
+    if: github.event_name == 'push'
     runs-on: pathfinder-large-ubuntu
     steps:
       - name: Determine Docker image metadata

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -23,6 +23,13 @@ mod subscription;
 
 pub use method::handle_json_rpc_body;
 
+const SNOS_RPC_METHOD_DURATION_SECONDS: &str = "pathfinder_snos_rpc_method_duration_seconds";
+const SNOS_RPC_METHODS: &[&str] = &[
+    "starknet_getStorageProof",
+    "starknet_getClass",
+    "starknet_getClassHashAt",
+];
+
 #[derive(Clone)]
 pub struct RpcRouter {
     pub context: RpcContext,
@@ -127,13 +134,13 @@ impl RpcRouter {
         metrics::counter!("rpc_method_calls_total", "method" => method_name, "version" => self.version.to_str()).increment(1);
 
         let start = std::time::Instant::now();
-
         let method = method
             .invoke(self.context.clone(), request.params, self.version)
             .instrument(tracing::debug_span!("rpc_call", method=%method_name));
         let result = std::panic::AssertUnwindSafe(method).catch_unwind().await;
 
         let duration = start.elapsed();
+        record_snos_rpc_method_duration(method_name, duration);
         metrics::histogram!("rpc_method_calls_duration_milliseconds", "method" => method_name, "version" => self.version.to_str()).record(duration.as_millis() as f64);
 
         let output = match result {
@@ -156,6 +163,15 @@ impl RpcRouter {
             version: self.version,
         })
     }
+}
+
+fn record_snos_rpc_method_duration(method_name: &'static str, duration: std::time::Duration) {
+    if !SNOS_RPC_METHODS.contains(&method_name) {
+        return;
+    }
+
+    metrics::histogram!(SNOS_RPC_METHOD_DURATION_SECONDS, "method" => method_name)
+        .record(duration.as_secs_f64());
 }
 
 // A slight variation on the axum json extractor.


### PR DESCRIPTION
## Summary
- add a SNOS-specific RPC duration histogram for the three methods SNOS calls heavily
- record durations as seconds with only the method label to keep cardinality bounded
- add a manual GHCR image build path using Blacksmith and linux/amd64, matching the Madara-style manual build architecture

## Metric
`pathfinder_snos_rpc_method_duration_seconds{method}`

Tracked methods:
- `starknet_getStorageProof`
- `starknet_getClass`
- `starknet_getClassHashAt`

## Validation
- `cargo check -p pathfinder-rpc`

## Image
Manual Docker workflow succeeded: https://github.com/karnotxyz/pathfinder/actions/runs/28110107948

Published image:
- `ghcr.io/karnotxyz/pathfinder:manual-a9772c9`
- digest: `sha256:f7731714019b85e9379aef7e24af3e48d4216623e45c1bd1bb38e98d7693177a`
- platform: `linux/amd64`