### PR TITLE
Add SNOS RPC method duration metrics on v0.22.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,72 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
+  manual-build-image:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-pathfinder
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Generate version
+        id: generate_version
+        run: |
+          git fetch --force --tags https://github.com/eqlabs/pathfinder.git 'refs/tags/v*:refs/tags/v*'
+          echo -n "pathfinder_version=" >> "$GITHUB_OUTPUT"
+          git describe --tags --dirty --always >> "$GITHUB_OUTPUT"
+
+      - name: Tags
+        id: tag
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/pathfinder"
+          SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
+          MANUAL_SHA="$IMAGE:manual-$SHA"
+          TAGS="$MANUAL_SHA"
+
+          echo "manual-sha=$MANUAL_SHA" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            MANUAL_LATEST="$IMAGE:manual-latest"
+            echo "manual-latest=$MANUAL_LATEST" >> "$GITHUB_OUTPUT"
+            TAGS="$TAGS"$'\n'"$MANUAL_LATEST"
+          fi
+
+          echo "tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+
+      - name: Build Docker Image and Publish
+        uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}
+          tags: ${{ steps.tag.outputs.tags }}
+
   # Build a docker image unless this was triggered by a release.
   build-image:
-    if: github.event_name != 'release'
+    if: github.event_name == 'push'
     runs-on: pathfinder-large-ubuntu
     steps:
       - name: Determine Docker image metadata

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -23,6 +23,13 @@ mod subscription;
 
 pub use method::handle_json_rpc_body;
 
+const SNOS_RPC_METHOD_DURATION_SECONDS: &str = "pathfinder_snos_rpc_method_duration_seconds";
+const SNOS_RPC_METHODS: &[&str] = &[
+    "starknet_getStorageProof",
+    "starknet_getClass",
+    "starknet_getClassHashAt",
+];
+
 #[derive(Clone)]
 pub struct RpcRouter {
     pub context: RpcContext,
@@ -134,6 +141,7 @@ impl RpcRouter {
         let result = std::panic::AssertUnwindSafe(method).catch_unwind().await;
 
         let duration = start.elapsed();
+        record_snos_rpc_method_duration(method_name, duration);
         metrics::histogram!("rpc_method_calls_duration_milliseconds", "method" => method_name, "version" => self.version.to_str()).record(duration.as_millis() as f64);
 
         let output = match result {
@@ -156,6 +164,15 @@ impl RpcRouter {
             version: self.version,
         })
     }
+}
+
+fn record_snos_rpc_method_duration(method_name: &'static str, duration: std::time::Duration) {
+    if !SNOS_RPC_METHODS.contains(&method_name) {
+        return;
+    }
+
+    metrics::histogram!(SNOS_RPC_METHOD_DURATION_SECONDS, "method" => method_name)
+        .record(duration.as_secs_f64());
 }
 
 // A slight variation on the axum json extractor.

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -25,9 +25,16 @@ pub use method::handle_json_rpc_body;
 
 const SNOS_RPC_METHOD_DURATION_SECONDS: &str = "pathfinder_snos_rpc_method_duration_seconds";
 const SNOS_RPC_METHODS: &[&str] = &[
-    "starknet_getStorageProof",
+    "starknet_chainId",
+    "starknet_getBlockWithReceipts",
+    "starknet_getBlockWithTxHashes",
+    "starknet_getBlockWithTxs",
     "starknet_getClass",
     "starknet_getClassHashAt",
+    "starknet_getNonce",
+    "starknet_getStateUpdate",
+    "starknet_getStorageAt",
+    "starknet_getStorageProof",
 ];
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- base this change directly on upstream EQLabs Pathfinder `v0.22.2` tag commit `95062ff7f1913958f5a8df71790a56263731e908`
- add a SNOS-specific RPC duration histogram for the three methods SNOS calls heavily
- record durations as seconds with only the method label to keep cardinality bounded
- add a manual GHCR image build path using Blacksmith and `linux/amd64`

## Metric
`pathfinder_snos_rpc_method_duration_seconds{method}`

Tracked methods:
- `starknet_getStorageProof`
- `starknet_getClass`
- `starknet_getClassHashAt`

## Validation
- `cargo check -p pathfinder-rpc`

## Image
Manual Docker workflow succeeded: https://github.com/karnotxyz/pathfinder/actions/runs/28112883437

Published image:
- `ghcr.io/karnotxyz/pathfinder:manual-f996364`
- digest: `sha256:1322c3acf5043fdcd909c4e616ba57c3194a6d6f57c368bb54d8c49f3f17c1cc`
- platform: `linux/amd64`
- build version: `v0.22.2-1-gf9963643d`

Earlier successful image `manual-d22798f` is functionally valid, but its embedded build version was only the commit SHA because the CI run did not yet fetch upstream EQLabs tags before `git describe`.