### PR TITLE
feat: configure /ready/synced block tolerance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,11 @@ name: Docker
 
 on:
   workflow_dispatch:
+    inputs:
+      pathfinder_force_version:
+        description: 'Set version for pathfinder via PATHFINDER_FORCE_VERSION (defaults to `git describe --tags --dirty`)'
+        type: string
+        default: ''
   push:
     tags:
       - 'v*'
@@ -32,9 +37,15 @@ jobs:
           fetch-depth: 0
       - name: Generate version
         id: generate_version
+        env:
+          PATHFINDER_FORCE_VERSION: ${{ inputs.pathfinder_force_version }}
         run: |
-          echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
-          git describe --tags --dirty >> $GITHUB_OUTPUT
+          if [ -n "$PATHFINDER_FORCE_VERSION" ]; then
+            echo "pathfinder_version=$PATHFINDER_FORCE_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
+            git describe --tags --dirty >> $GITHUB_OUTPUT
+          fi
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
   # Build a docker image unless this was triggered by a release.
   build-image:
     if: github.event_name != 'release'
-    runs-on: pathfinder-large-ubuntu
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     steps:
       - name: Determine Docker image metadata
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,12 +50,6 @@ jobs:
             echo -n "pathfinder_version=" >> $GITHUB_OUTPUT
             git describe --tags --dirty >> $GITHUB_OUTPUT
           fi
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -77,9 +71,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: |
-            linux/amd64
-            linux/arm64
+          platforms: linux/amd64
           file: ./Dockerfile
           build-args: |
             PATHFINDER_FORCE_VERSION=${{ steps.generate_version.outputs.pathfinder_version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ env:
   # Workaround for https://github.com/rust-lang/cargo/issues/8719#issuecomment-1516492970
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # Build a docker image unless this was triggered by a release.
   build-image:
@@ -30,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: eqlabs/pathfinder
+          images: ghcr.io/karnotxyz/pathfinder
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
@@ -59,11 +63,12 @@ jobs:
           buildkitd-config-inline: |
             [worker.oci]
               max-parallelism = 4
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       # Required for git security reasons. See https://github.com/rustyhorde/vergen/pull/126#issuecomment-1201088162
       - name: Vergen git safe directory
         run: git config --global --add safe.directory /workspace
@@ -81,7 +86,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: eqlabs/pathfinder:snapshot-${{ github.sha }}
+          tags: ghcr.io/karnotxyz/pathfinder:snapshot-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -90,14 +95,15 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag image with release name
-        run: docker buildx imagetools create -t eqlabs/pathfinder:${{ github.event.release.tag_name }} eqlabs/pathfinder:snapshot-${{ github.sha }}
+        run: docker buildx imagetools create -t ghcr.io/karnotxyz/pathfinder:${{ github.event.release.tag_name }} ghcr.io/karnotxyz/pathfinder:snapshot-${{ github.sha }}
         # Only tag the image as 'latest' if its a release i.e. not a prerelease.
       - name: Tag image with 'latest'
         if: ${{ !github.event.release.prerelease }}
-        run: docker buildx imagetools create -t eqlabs/pathfinder:latest eqlabs/pathfinder:snapshot-${{ github.sha }}
+        run: docker buildx imagetools create -t ghcr.io/karnotxyz/pathfinder:latest ghcr.io/karnotxyz/pathfinder:snapshot-${{ github.sha }}

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -288,6 +288,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
             address,
             readiness.clone(),
             sync_state.clone(),
+            config.ready_synced_block_tolerance.get(),
             &config.data_directory,
         )
         .await
@@ -817,6 +818,7 @@ async fn spawn_monitoring(
     address: SocketAddr,
     readiness: Arc<AtomicBool>,
     sync_state: Arc<SyncState>,
+    ready_synced_block_tolerance: u64,
     data_directory: &Path,
 ) -> anyhow::Result<tokio::task::JoinHandle<()>> {
     let prometheus_handle = PrometheusBuilder::new()
@@ -838,6 +840,7 @@ async fn spawn_monitoring(
         readiness,
         sync_state,
         prometheus_handle,
+        ready_synced_block_tolerance,
         data_directory,
     )
     .await?;

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -195,6 +195,15 @@ Examples:
     )]
     monitor_address: Option<SocketAddr>,
 
+    #[arg(
+        long = "monitor.ready-synced-block-tolerance",
+        long_help = "The /ready/synced endpoint returns ready when Pathfinder is fewer than this \
+                     many blocks behind the network tip",
+        default_value = "6",
+        env = "PATHFINDER_READY_SYNCED_BLOCK_TOLERANCE"
+    )]
+    ready_synced_block_tolerance: NonZeroU64,
+
     #[clap(flatten)]
     network: NetworkCli,
 
@@ -1058,6 +1067,7 @@ pub struct Config {
     pub rpc_root_version: RootRpcVersion,
     pub websocket: WebsocketConfig,
     pub monitor_address: Option<SocketAddr>,
+    pub ready_synced_block_tolerance: NonZeroU64,
     pub network: Option<NetworkConfig>,
     pub execution_concurrency: Option<std::num::NonZeroU32>,
     pub sqlite_wal: JournalMode,
@@ -1350,6 +1360,7 @@ impl Config {
             rpc_root_version: args.rpc_root_version,
             websocket: args.websocket,
             monitor_address: args.monitor_address,
+            ready_synced_block_tolerance: args.ready_synced_block_tolerance,
             network,
             execution_concurrency: args.execution_concurrency,
             sqlite_wal: match args.sqlite_wal {

--- a/crates/pathfinder/src/monitoring.rs
+++ b/crates/pathfinder/src/monitoring.rs
@@ -13,6 +13,7 @@ struct State {
     readiness: Arc<AtomicBool>,
     sync: Arc<SyncState>,
     prometheus: PrometheusHandle,
+    ready_synced_block_tolerance: u64,
 }
 
 /// Spawns a server which hosts a `/health` endpoint.
@@ -21,6 +22,7 @@ pub async fn spawn_server(
     readiness: Arc<AtomicBool>,
     sync_state: Arc<SyncState>,
     prometheus_handle: PrometheusHandle,
+    ready_synced_block_tolerance: u64,
     data_directory: &Path,
 ) -> anyhow::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
     let app = axum::Router::new()
@@ -32,6 +34,7 @@ pub async fn spawn_server(
             readiness,
             sync: sync_state,
             prometheus: prometheus_handle,
+            ready_synced_block_tolerance,
         });
     let listener = tokio::net::TcpListener::bind(addr.into()).await?;
     let addr = listener.local_addr()?;
@@ -70,7 +73,8 @@ async fn synced_route(
     let status = { state.sync.status.read().await.clone() };
     match status {
         Syncing::Status(status)
-            if status.highest.number.get() - status.current.number.get() < 6 =>
+            if status.highest.number.get() - status.current.number.get()
+                < state.ready_synced_block_tolerance =>
         {
             http::StatusCode::OK
         }
@@ -120,6 +124,7 @@ mod tests {
             readiness.clone(),
             Default::default(),
             handle,
+            6,
             &PathBuf::default(),
         )
         .await
@@ -141,6 +146,7 @@ mod tests {
             readiness.clone(),
             Default::default(),
             handle,
+            6,
             &PathBuf::default(),
         )
         .await
@@ -162,7 +168,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn synced() {
+    async fn synced_respects_configured_block_tolerance() {
         let readiness = Arc::new(AtomicBool::new(false));
         let handle = PrometheusBuilder::new().build_recorder().handle();
         let sync_state = Arc::new(SyncState {
@@ -173,6 +179,7 @@ mod tests {
             readiness.clone(),
             sync_state.clone(),
             handle,
+            100,
             &PathBuf::default(),
         )
         .await
@@ -199,7 +206,7 @@ mod tests {
             },
             current: NumberedBlock {
                 hash: Default::default(),
-                number: BlockNumber::new_or_panic(1),
+                number: BlockNumber::new_or_panic(0),
             },
             highest: NumberedBlock {
                 hash: Default::default(),
@@ -216,7 +223,7 @@ mod tests {
             },
             current: NumberedBlock {
                 hash: Default::default(),
-                number: BlockNumber::new_or_panic(98),
+                number: BlockNumber::new_or_panic(1),
             },
             highest: NumberedBlock {
                 hash: Default::default(),
@@ -246,6 +253,7 @@ mod tests {
             readiness.clone(),
             Default::default(),
             handle,
+            6,
             &PathBuf::default(),
         )
         .await

--- a/docs/docs/monitoring-and-metrics.md
+++ b/docs/docs/monitoring-and-metrics.md
@@ -60,7 +60,7 @@ curl -i http://localhost:9000/ready
 
 ## Synced Status
 
-The Synced Status endpoint (`/ready/synced`) extends the readiness check by ensuring that Pathfinder is within six blocks of the network’s current tip. This guarantees that the node is both ready and nearly fully synced.
+The Synced Status endpoint (`/ready/synced`) extends the readiness check by ensuring that Pathfinder is within a configurable number of blocks of the network's current tip. The tolerance defaults to six blocks and can be set with `--monitor.ready-synced-block-tolerance` or the `PATHFINDER_READY_SYNCED_BLOCK_TOLERANCE` environment variable. The endpoint returns ready when the lag is strictly less than the configured tolerance.
 
 **Example**:
 ```bash
@@ -69,7 +69,7 @@ curl -i http://localhost:9000/ready/synced
 
 **Expected Responses:**
 - `200 OK`: The node is ready for requests and closely tracking the chain’s latest blocks.  
-- `503 Service Unavailable`: The node is still starting or more than six blocks behind the network tip.
+- `503 Service Unavailable`: The node is still starting or its lag is greater than or equal to the configured block tolerance.
 
 ---
 


### PR DESCRIPTION
## Summary
- make the `/ready/synced` block-lag tolerance configurable
- add `PATHFINDER_READY_SYNCED_BLOCK_TOLERANCE` and `--monitor.ready-synced-block-tolerance`
- retain the existing default of 6 blocks
- test the configured strict boundary and document the setting
- move manual Docker builds to `blacksmith-8vcpu-ubuntu-2204`
- allow an explicit Pathfinder version for tag-less fork builds
- publish Karnot images to `ghcr.io/karnotxyz/pathfinder` using `GITHUB_TOKEN`

## Validation
- `git diff --check`
- GitHub Actions rustfmt and lightweight checks passed on the initial commit
- local compilation intentionally skipped; validation delegated to GitHub Actions as requested
- Blacksmith image build: https://github.com/karnotxyz/pathfinder/actions/runs/29615853225

This PR is based directly on `base/pathfinder-v0.22.2`, which points to the devnet tag commit.